### PR TITLE
Get Tooltip text from component attributes - Fixes #3

### DIFF
--- a/js/src/forum/components/TextEditorButton.js
+++ b/js/src/forum/components/TextEditorButton.js
@@ -13,7 +13,7 @@ export default class TextEditorButton extends Button {
     const originalView = super.view(vnode);
 
     // Steal tooltip label from the Button superclass
-    const tooltipText = originalView.attrs.title;
+    const tooltipText = this.attrs.tooltipText || originalView.attrs.title;
     delete originalView.attrs.title;
 
     return (
@@ -27,5 +27,6 @@ export default class TextEditorButton extends Button {
     super.initAttrs(attrs);
 
     attrs.className = 'Button Button--icon Button--link Button-flamoji';
+    attrs.tooltipText = attrs.title;
   }
 }


### PR DESCRIPTION
Implements changes from the original Flarum's [TextEditorButton](https://github.com/flarum/framework/blob/a7dd0b2b61695aea327dd82b77658ce1089b061c/framework/core/js/src/common/components/TextEditorButton.js) component and fixes the tooltip showing "undefined"